### PR TITLE
refactor: move route-definitions to AppRouter #40

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import axios, { AxiosInstance } from 'axios';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Container from "@mui/material/Container";
 
 import { GlobalHeader } from "./common/components";
-import { Home } from './home/components/HomeContainer';
-import { Gomoku } from "./gomoku/components/GomokuContainer";
 import { AxiosClientProvider } from "./common/context/axiosClientProvider";
+import AppRouter from './AppRouter';
 
 const App: React.FC = () => {
   if (!process.env.REACT_APP_GOMOKU_API_URL) {
@@ -22,10 +20,7 @@ const App: React.FC = () => {
     <AxiosClientProvider axiosClient={client}>
       <GlobalHeader />
       <Container maxWidth="xl" sx={{marginTop: "60px"}}>
-        <Router basename={process.env.PUBLIC_URL}>
-          <Route path="/" exact component={Home}></Route>
-          <Route path="/game" exact component={Gomoku}></Route>
-        </Router>
+        <AppRouter />
       </Container>
     </AxiosClientProvider>
   );

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,0 +1,17 @@
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+
+import { Home } from './home/components/homeContainer';
+import { Gomoku } from "./gomoku/components/gomokuContainer";
+
+import { homePath, gomokuPath } from './common/utils/paths';
+
+const AppRouter: React.FC = () => {
+    return (
+        <Router basename={process.env.PUBLIC_URL}>
+            <Route path={homePath} exact component={Home}></Route>
+            <Route path={gomokuPath} exact component={Gomoku}></Route>
+      </Router>
+    )
+}
+
+export default AppRouter;

--- a/src/common/utils/paths.ts
+++ b/src/common/utils/paths.ts
@@ -1,0 +1,2 @@
+export const homePath = "/";
+export const gomokuPath = "/game";


### PR DESCRIPTION
Close #40 
## 概要
- ルーティング関連のコードを新しいファイルへ移行しました
(`App.tsx`と同階層に`AppRouter.tsx`を作成)
- `src/common/utils/paths.ts`を作成し、ルート定義で使用するパスをまとめました